### PR TITLE
Added Startpage Support

### DIFF
--- a/MMM-HideShowMove.js
+++ b/MMM-HideShowMove.js
@@ -61,6 +61,7 @@ Module.register("MMM-HideShowMove", {
     PAGEFOUR: [],
     PAGEFIVE: [],
     PAGESIX: [],
+    Startpage : "",
   },
 
 
@@ -108,6 +109,7 @@ Module.register("MMM-HideShowMove", {
     "TIMER"       : "MMM-EventHorizon",
     "TRIVIA"      : "MMM-ATM",
     "WEATHER"     : "weatherforecast"
+    
   },
 
   start() {
@@ -207,6 +209,12 @@ Module.register("MMM-HideShowMove", {
       case moveTopic:
         this.moveModule(payload);
         break;
+      case 'DOM_OBJECTS_CREATED':
+        if(this.config.Startpage != ""){
+            MM.getModules().exceptWithClass(this.config[this.config.Startpage]).exceptWithClass(this.name).enumerate(module => module.hide());
+        }
+        break;
+        
       default:
         break;
     }


### PR DESCRIPTION
Hello,

I had an additional idea. It would be great if you can define a startpage, so that all modules except the modules on the startpage are hidden when Magic Mirror starts. I added this to your module and made a pull request. For this i needed a config-paramater. Now you can just write in your config.js
Startpage: "PAGEONE" and the Magic Mirror starts with page one. If the parameter Startpage is empty (which is default) then nothing happens.

Greetings
Markus